### PR TITLE
feat: discover page with movie recommendation queue

### DIFF
--- a/actions/index.ts
+++ b/actions/index.ts
@@ -1,9 +1,11 @@
 'use server'
 
 import * as db from '@/db/queries'
-import type { MovieWithMeanRating, MovieWithUserRating, Rating, Watched } from '@/db/types'
+import type { MovieWithMeanRating, MovieWithUserRating, Rating, Skip, Watched } from '@/db/types'
+import { getMovieByImdbId, getMovieDetails } from '@/lib/tmdb'
+import type { MovieDetails } from '@/lib/tmdb'
 import { auth } from '@/lib/auth'
-import { getMovieByImdbId } from '@/lib/tmdb'
+import { getRecommendations } from '@/lib/recommender'
 import { headers } from 'next/headers'
 import { sum } from 'radash'
 import { z } from 'zod'
@@ -138,4 +140,61 @@ export const deleteWatched = async (dto: z.input<typeof MovieDto>): Promise<void
   const { id: userId } = await getUser()
   const { imdbId } = MovieDto.parse(dto)
   await db.deleteWatched(userId, imdbId)
+}
+
+/* SKIPS */
+
+export const getSkip = async (dto: z.input<typeof MovieDto>): Promise<Skip | null> => {
+  const { id: userId } = await getUser()
+  const { imdbId } = MovieDto.parse(dto)
+  const skip = await db.getSkip(userId, imdbId)
+  return skip ?? null
+}
+
+export const skipMovie = async (dto: z.input<typeof MovieDto>): Promise<void> => {
+  const { id: userId } = await getUser()
+  const { imdbId } = MovieDto.parse(dto)
+  await ensureMovie({ imdbId })
+  await db.addSkip(userId, imdbId)
+}
+
+export const undoSkip = async (dto: z.input<typeof MovieDto>): Promise<void> => {
+  const { id: userId } = await getUser()
+  const { imdbId } = MovieDto.parse(dto)
+  await db.deleteSkip(userId, imdbId)
+}
+
+/* DISCOVER */
+
+const DiscoverBatchDto = z.object({
+  excludeTmdbIds: z.array(z.number()).optional(),
+  batchSize: z.number().min(1).max(20).optional(),
+})
+
+export const getDiscoverBatch = async (
+  dto: z.input<typeof DiscoverBatchDto> = {},
+): Promise<MovieDetails[]> => {
+  const { id: userId } = await getUser()
+  const { excludeTmdbIds = [], batchSize = 10 } = DiscoverBatchDto.parse(dto)
+
+  const candidates = await getRecommendations({
+    userId,
+    batchSize,
+    additionalExcludeTmdbIds: excludeTmdbIds,
+  })
+
+  const details = await Promise.all(candidates.map((m) => getMovieDetails(m.id)))
+
+  const withImdbId = details.filter((d) => d.imdb_id !== null)
+
+  await Promise.all(
+    withImdbId.map((d) =>
+      db.upsertMovie(d.imdb_id as string, {
+        ...d,
+        genre_ids: d.genres.map((g) => g.id),
+      }),
+    ),
+  )
+
+  return withImdbId
 }

--- a/app/discover/page.tsx
+++ b/app/discover/page.tsx
@@ -1,0 +1,30 @@
+import { DiscoverQueue } from '@/components/discover-queue'
+import { auth } from '@/lib/auth'
+import { getDiscoverBatch } from '@/actions'
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata = {
+  title: 'Discover - Movie Mingle',
+  description: 'Discover movies to rate',
+}
+
+export default async function DiscoverPage() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    redirect('/')
+  }
+
+  const initialBatch = await getDiscoverBatch({ batchSize: 10 })
+
+  return (
+    <main className="flex min-h-[calc(100vh-56px)] w-full flex-col items-center gap-6 px-4 pt-10 pb-8">
+      <div className="w-full max-w-3xl">
+        <h1 className="mb-6 text-3xl font-bold">Discover</h1>
+        <DiscoverQueue initialBatch={initialBatch} />
+      </div>
+    </main>
+  )
+}

--- a/components/discover-card.tsx
+++ b/components/discover-card.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { Button, buttonVariants } from './ui/button'
+import { CalendarIcon, StarIcon } from 'lucide-react'
+import {
+  type MovieDetails,
+  formatRuntime,
+  getBackdropImageUrl,
+  getPosterImageUrl,
+  getYear,
+} from '@/lib/tmdb'
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
+import { setRating, setWatched, skipMovie } from '@/actions'
+import { Calendar } from './ui/calendar'
+import Image from 'next/image'
+import Link from 'next/link'
+import { PosterImage } from './poster-image'
+import { Slider } from './ui/slider'
+import { cn } from '@/lib/tailwind'
+import { format } from 'date-fns'
+import { getMovieUrl } from '@/lib/url'
+import { useMutation } from '@tanstack/react-query'
+import { useState } from 'react'
+
+const getRatingDescription = (rating: number) => {
+  if (rating < 1) return 'Dumpster fire'
+  if (rating < 2) return "Wouldn't rewatch even if paid"
+  if (rating < 3) return 'Garbage'
+  if (rating < 4) return 'Bad'
+  if (rating < 5) return 'Meh'
+  if (rating < 6) return 'Alright'
+  if (rating < 7) return 'Good'
+  if (rating < 8) return 'Great'
+  if (rating < 9) return 'Goddamn'
+  if (rating < 10) return 'One of the best'
+  return 'A masterpiece'
+}
+
+type Props = {
+  movie: MovieDetails
+  onAdvance: () => void
+}
+
+export const DiscoverCard = ({ movie, onAdvance }: Props) => {
+  const [ratingValue, setRatingValue] = useState<number>(5)
+  const [watchDate, setWatchDate] = useState<Date | undefined>(undefined)
+  const [calendarOpen, setCalendarOpen] = useState(false)
+
+  const imdbId = movie.imdb_id!
+  const backdropUrl = movie.backdrop_path ? getBackdropImageUrl(movie.backdrop_path) : null
+  const posterUrl = movie.poster_path ? getPosterImageUrl(movie.poster_path, 'original') : null
+  const year = getYear(movie.release_date)
+  const genres = movie.genres.map((g) => g.name).join(', ')
+  const runtime = movie.runtime > 0 ? formatRuntime(movie.runtime) : null
+
+  const rateMutation = useMutation({
+    mutationFn: async () => {
+      await setRating({ imdbId, rating: ratingValue })
+      if (watchDate) {
+        await setWatched({ imdbId, date: format(watchDate, 'yyyy-MM-dd') })
+      }
+    },
+    onSuccess: onAdvance,
+  })
+
+  const skipMutation = useMutation({
+    mutationFn: () => skipMovie({ imdbId }),
+    onSuccess: onAdvance,
+  })
+
+  const isPending = rateMutation.isPending || skipMutation.isPending
+
+  return (
+    <div className="relative w-full max-w-3xl overflow-hidden rounded-xl bg-card shadow-lg">
+      {backdropUrl && (
+        <Image
+          src={backdropUrl}
+          alt={`Backdrop of ${movie.title}`}
+          fill
+          priority
+          className="pointer-events-none object-cover object-[50%_20%] opacity-15"
+        />
+      )}
+
+      <div className="relative z-10 flex flex-col gap-6 p-6">
+        {/* Movie info */}
+        <div className="flex flex-col gap-6 sm:flex-row sm:items-start">
+          <Link
+            href={getMovieUrl(movie.id, movie.title)}
+            className="mx-auto shrink-0 sm:mx-0"
+            tabIndex={-1}
+          >
+            <div className="relative aspect-2/3 w-40 overflow-hidden rounded-md">
+              <PosterImage title={movie.title} posterUrl={posterUrl} className="h-full" />
+              {posterUrl && (
+                <Image
+                  src={posterUrl}
+                  alt={`Poster of ${movie.title}`}
+                  fill
+                  priority
+                  className="object-cover"
+                />
+              )}
+            </div>
+          </Link>
+
+          <div className="flex min-w-0 flex-col gap-2">
+            <Link href={getMovieUrl(movie.id, movie.title)} className="hover:underline">
+              <h2 className="text-2xl font-bold">
+                {movie.title} <span className="font-normal text-muted-foreground">({year})</span>
+              </h2>
+            </Link>
+
+            <p className="text-sm text-muted-foreground">
+              {[genres, runtime].filter(Boolean).join(' • ')}
+            </p>
+
+            {movie.overview && (
+              <p className="line-clamp-4 text-sm text-muted-foreground">{movie.overview}</p>
+            )}
+
+            <p className="text-sm text-muted-foreground">
+              TMDB{' '}
+              <span className="font-semibold text-foreground">{movie.vote_average.toFixed(1)}</span>
+              /10 <span className="text-xs">({movie.vote_count.toLocaleString()} votes)</span>
+            </p>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col gap-4 border-t border-border pt-4">
+          {/* Rating slider */}
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <span className="flex items-center gap-1.5 text-sm font-medium">
+                <StarIcon className="size-4 fill-primary text-primary" />
+                Your rating
+              </span>
+              <span className="text-sm text-muted-foreground">
+                <span className="font-semibold text-foreground">{ratingValue.toFixed(1)}</span>
+                /10 — {getRatingDescription(ratingValue)}
+              </span>
+            </div>
+            <Slider
+              value={ratingValue}
+              onValueChange={(v) => setRatingValue(v as number)}
+              min={0}
+              max={10}
+              step={0.5}
+            />
+          </div>
+
+          {/* Watch date + action buttons */}
+          <div className="flex items-center gap-3">
+            <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+              <PopoverTrigger
+                disabled={isPending}
+                className={cn(
+                  buttonVariants({ variant: 'outline' }),
+                  'gap-2',
+                  watchDate ? 'text-foreground' : 'text-muted-foreground',
+                )}
+              >
+                <CalendarIcon className="size-4" />
+                {watchDate ? format(watchDate, 'dd / MM / yyyy') : 'Watch date'}
+              </PopoverTrigger>
+              <PopoverContent>
+                <Calendar
+                  mode="single"
+                  selected={watchDate}
+                  onSelect={(date) => {
+                    setWatchDate(date)
+                    setCalendarOpen(false)
+                  }}
+                  captionLayout="dropdown"
+                  weekStartsOn={1}
+                  autoFocus
+                />
+              </PopoverContent>
+            </Popover>
+
+            <div className="flex flex-1 justify-end gap-3">
+              <Button
+                variant="ghost"
+                onClick={() => skipMutation.mutate()}
+                disabled={isPending}
+                className="text-muted-foreground"
+              >
+                Skip
+              </Button>
+              <Button onClick={() => rateMutation.mutate()} disabled={isPending}>
+                Rate
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/discover-queue.tsx
+++ b/components/discover-queue.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { DiscoverCard } from './discover-card'
+import type { MovieDetails } from '@/lib/tmdb'
+import { Skeleton } from './ui/skeleton'
+import { getDiscoverBatch } from '@/actions'
+
+const PREFETCH_THRESHOLD = 3
+const BATCH_SIZE = 10
+
+type Props = {
+  initialBatch: MovieDetails[]
+}
+
+export const DiscoverQueue = ({ initialBatch }: Props) => {
+  const [queue, setQueue] = useState<MovieDetails[]>(initialBatch)
+  const [isFetching, setIsFetching] = useState(false)
+  const [exhausted, setExhausted] = useState(false)
+  const fetchingRef = useRef(false)
+
+  const fetchMore = useCallback(async (currentQueue: MovieDetails[]) => {
+    if (fetchingRef.current) return
+    fetchingRef.current = true
+    setIsFetching(true)
+
+    try {
+      const excludeTmdbIds = currentQueue.map((m) => m.id)
+      const batch = await getDiscoverBatch({ excludeTmdbIds, batchSize: BATCH_SIZE })
+
+      if (batch.length === 0) {
+        setExhausted(true)
+      } else {
+        setQueue((prev) => [...prev, ...batch])
+      }
+    } finally {
+      fetchingRef.current = false
+      setIsFetching(false)
+    }
+  }, [])
+
+  // Prefetch when queue runs low
+  useEffect(() => {
+    if (!exhausted && queue.length < PREFETCH_THRESHOLD && !fetchingRef.current) {
+      fetchMore(queue)
+    }
+  }, [queue, exhausted, fetchMore])
+
+  const handleAdvance = useCallback(() => {
+    setQueue((prev) => prev.slice(1))
+  }, [])
+
+  if (queue.length === 0) {
+    if (isFetching) {
+      return <DiscoverCardSkeleton />
+    }
+    if (exhausted) {
+      return (
+        <div className="flex flex-col items-center gap-2 text-center text-muted-foreground">
+          <p className="text-lg font-semibold">You're all caught up!</p>
+          <p className="text-sm">No more movies to discover right now. Check back later.</p>
+        </div>
+      )
+    }
+    return null
+  }
+
+  const current = queue[0]
+
+  return (
+    <div className="flex w-full flex-col items-center gap-4">
+      <DiscoverCard key={current.id} movie={current} onAdvance={handleAdvance} />
+      <p className="text-xs text-muted-foreground">
+        {queue.length - 1} more in queue
+        {isFetching && ' · loading more…'}
+      </p>
+    </div>
+  )
+}
+
+const DiscoverCardSkeleton = () => {
+  return <Skeleton className="h-96 w-full max-w-3xl rounded-xl" />
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -30,12 +30,20 @@ export const Header = async () => {
           <div className="flex items-center space-x-1 sm:space-x-4">
             <SearchMoviesDialog />
             {isAuthenticated && (
-              <Link
-                href="/ratings"
-                className="text-sm font-medium text-foreground/80 transition-colors hover:text-foreground"
-              >
-                My Ratings
-              </Link>
+              <>
+                <Link
+                  href="/discover"
+                  className="text-sm font-medium text-foreground/80 transition-colors hover:text-foreground"
+                >
+                  Discover
+                </Link>
+                <Link
+                  href="/ratings"
+                  className="text-sm font-medium text-foreground/80 transition-colors hover:text-foreground"
+                >
+                  My Ratings
+                </Link>
+              </>
             )}
             <UserMenu />
           </div>

--- a/db/queries.ts
+++ b/db/queries.ts
@@ -1,8 +1,9 @@
 import 'server-only'
 import { and, avg, count, desc, eq, sql } from 'drizzle-orm'
-import { movies, ratings, watched } from './schema'
+import { movies, ratings, skips, watched } from './schema'
 import { Movie } from '../lib/tmdb'
 import { db } from '.'
+import { union } from 'drizzle-orm/pg-core'
 
 /* MOVIES */
 
@@ -214,4 +215,70 @@ export const setWatched = async (userId: string, imdbId: string, date: string) =
 
 export const deleteWatched = async (userId: string, imdbId: string) => {
   return db.delete(watched).where(and(eq(watched.userId, userId), eq(watched.imdbId, imdbId)))
+}
+
+/* SKIPS */
+
+export const getSkip = async (userId: string, imdbId: string) => {
+  return db.query.skips.findFirst({
+    where: and(eq(skips.userId, userId), eq(skips.imdbId, imdbId)),
+  })
+}
+
+export const addSkip = async (userId: string, imdbId: string) => {
+  const [result] = await db
+    .insert(skips)
+    .values({ userId, imdbId })
+    .onConflictDoNothing()
+    .returning()
+  return result
+}
+
+export const deleteSkip = async (userId: string, imdbId: string) => {
+  return db.delete(skips).where(and(eq(skips.userId, userId), eq(skips.imdbId, imdbId)))
+}
+
+/* DISCOVER */
+
+export type UserExclusions = {
+  /** tmdbIds of movies the user has rated or watched — never show again */
+  hard: number[]
+  /** tmdbIds of movies the user has skipped recently — suppress for now */
+  recentlySkipped: number[]
+}
+
+export const getUserExclusions = async (
+  userId: string,
+  skipCooldownDays: number = 30,
+): Promise<UserExclusions> => {
+  const ratedImdbIds = db
+    .select({ imdbId: ratings.imdbId })
+    .from(ratings)
+    .where(eq(ratings.userId, userId))
+
+  const watchedImdbIds = db
+    .select({ imdbId: watched.imdbId })
+    .from(watched)
+    .where(eq(watched.userId, userId))
+
+  const hardExcludedImdbIds = union(ratedImdbIds, watchedImdbIds).as('hard_excluded_imdb_ids')
+
+  const hardResult = await db
+    .select({ tmdbId: movies.tmdbId })
+    .from(movies)
+    .innerJoin(hardExcludedImdbIds, eq(movies.imdbId, hardExcludedImdbIds.imdbId))
+
+  const cooldownCutoff = new Date()
+  cooldownCutoff.setDate(cooldownCutoff.getDate() - skipCooldownDays)
+
+  const recentSkipsResult = await db
+    .select({ tmdbId: movies.tmdbId })
+    .from(skips)
+    .innerJoin(movies, eq(skips.imdbId, movies.imdbId))
+    .where(and(eq(skips.userId, userId), sql`${skips.createdAt} > ${cooldownCutoff.toISOString()}`))
+
+  return {
+    hard: hardResult.map((r) => r.tmdbId),
+    recentlySkipped: recentSkipsResult.map((r) => r.tmdbId),
+  }
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -74,3 +74,17 @@ export const watched = pgTable(
   },
   (table) => [primaryKey({ columns: [table.imdbId, table.userId] })],
 )
+
+export const skips = pgTable(
+  'skips',
+  {
+    imdbId: text('imdb_id')
+      .notNull()
+      .references(() => movies.imdbId),
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.imdbId, table.userId] })],
+)

--- a/db/types.ts
+++ b/db/types.ts
@@ -1,8 +1,9 @@
-import { movies, ratings, watched } from './schema'
+import { movies, ratings, skips, watched } from './schema'
 
 export type Movie = typeof movies.$inferSelect
 export type Watched = typeof watched.$inferSelect
 export type Rating = typeof ratings.$inferSelect
+export type Skip = typeof skips.$inferSelect
 
 export type MovieWithMeanRating = Movie & {
   voteMean: number

--- a/drizzle/0001_add_skips_table.sql
+++ b/drizzle/0001_add_skips_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "skips" (
+	"imdb_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "skips_imdb_id_user_id_pk" PRIMARY KEY("imdb_id","user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "skips" ADD CONSTRAINT "skips_imdb_id_movies_imdb_id_fk" FOREIGN KEY ("imdb_id") REFERENCES "public"."movies"("imdb_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "skips" ADD CONSTRAINT "skips_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,713 @@
+{
+  "id": "f24b2399-6cdf-4c1b-8258-c2a13ae53960",
+  "prevId": "9cf9dcd2-7cb0-4378-9cce-2ee608a4adb1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.movies": {
+      "name": "movies",
+      "schema": "",
+      "columns": {
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre_ids": {
+          "name": "genre_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imdb_vote_count": {
+          "name": "imdb_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imdb_vote_mean": {
+          "name": "imdb_vote_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tmdb_vote_count": {
+          "name": "tmdb_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tmdb_vote_mean": {
+          "name": "tmdb_vote_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_tmdb_id_unique": {
+          "name": "movies_tmdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ratings": {
+      "name": "ratings",
+      "schema": "",
+      "columns": {
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ratings_imdb_id_movies_imdb_id_fk": {
+          "name": "ratings_imdb_id_movies_imdb_id_fk",
+          "tableFrom": "ratings",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "imdb_id"
+          ],
+          "columnsTo": [
+            "imdb_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ratings_user_id_user_id_fk": {
+          "name": "ratings_user_id_user_id_fk",
+          "tableFrom": "ratings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ratings_imdb_id_user_id_pk": {
+          "name": "ratings_imdb_id_user_id_pk",
+          "columns": [
+            "imdb_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ratings_value_range": {
+          "name": "ratings_value_range",
+          "value": "\"ratings\".\"value\" BETWEEN 0 AND 10"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.skips": {
+      "name": "skips",
+      "schema": "",
+      "columns": {
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skips_imdb_id_movies_imdb_id_fk": {
+          "name": "skips_imdb_id_movies_imdb_id_fk",
+          "tableFrom": "skips",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "imdb_id"
+          ],
+          "columnsTo": [
+            "imdb_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "skips_user_id_user_id_fk": {
+          "name": "skips_user_id_user_id_fk",
+          "tableFrom": "skips",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "skips_imdb_id_user_id_pk": {
+          "name": "skips_imdb_id_user_id_pk",
+          "columns": [
+            "imdb_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watched": {
+      "name": "watched",
+      "schema": "",
+      "columns": {
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watched_imdb_id_movies_imdb_id_fk": {
+          "name": "watched_imdb_id_movies_imdb_id_fk",
+          "tableFrom": "watched",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "imdb_id"
+          ],
+          "columnsTo": [
+            "imdb_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "watched_user_id_user_id_fk": {
+          "name": "watched_user_id_user_id_fk",
+          "tableFrom": "watched",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "watched_imdb_id_user_id_pk": {
+          "name": "watched_imdb_id_user_id_pk",
+          "columns": [
+            "imdb_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1766744537525,
       "tag": "0000_soft_doctor_octopus",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776215917270,
+      "tag": "0001_add_skips_table",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/recommender/index.ts
+++ b/lib/recommender/index.ts
@@ -1,0 +1,54 @@
+import 'server-only'
+import type { Movie } from '@/lib/tmdb'
+import { getPopularMovies } from '@/lib/tmdb'
+import { getUserExclusions } from '@/db/queries'
+
+const PAGES_TO_FETCH = 5
+
+export type RecommendationStrategy = (params: {
+  userId: string
+  batchSize: number
+  additionalExcludeTmdbIds?: number[]
+}) => Promise<Movie[]>
+
+/**
+ * Simple strategy: filter TMDB popular movies by exclusions.
+ *
+ * Hard exclusions (rated/watched) are never shown.
+ * Recent skips are deprioritised — they go to the back of the candidate pool
+ * so un-skipped movies appear first, but skipped movies can resurface if
+ * the pool runs dry.
+ */
+const popularMoviesStrategy: RecommendationStrategy = async ({
+  userId,
+  batchSize,
+  additionalExcludeTmdbIds = [],
+}) => {
+  const exclusions = await getUserExclusions(userId)
+
+  const hardExcluded = new Set([...exclusions.hard, ...additionalExcludeTmdbIds])
+  const softExcluded = new Set(exclusions.recentlySkipped)
+
+  const pages = await Promise.all(
+    Array.from({ length: PAGES_TO_FETCH }, (_, i) => getPopularMovies(i + 1)),
+  )
+
+  const preferred: Movie[] = []
+  const deprioritised: Movie[] = []
+
+  for (const page of pages) {
+    for (const movie of page.results) {
+      if (hardExcluded.has(movie.id)) continue
+      if (softExcluded.has(movie.id)) {
+        deprioritised.push(movie)
+      } else {
+        preferred.push(movie)
+      }
+    }
+  }
+
+  // Fill from preferred first, then fall back to deprioritised
+  return [...preferred, ...deprioritised].slice(0, batchSize)
+}
+
+export const getRecommendations = popularMoviesStrategy

--- a/lib/tmdb/actions.ts
+++ b/lib/tmdb/actions.ts
@@ -66,3 +66,7 @@ export const getMovieByImdbId = async (imdbId: string): Promise<Movie> => {
 
   return external.movie_results[0]
 }
+
+export const getPopularMovies = async (page: number = 1): Promise<SearchMoviesResponse> => {
+  return tmdbFetch(`/movie/popular?page=${page}`, searchMoviesResponseSchema)
+}

--- a/lib/tmdb/constants.ts
+++ b/lib/tmdb/constants.ts
@@ -5,3 +5,25 @@ export const TMDB_IMAGE_SIZE_POSTER_SMALL = 'w154' as const
 export const TMDB_IMAGE_SIZE_POSTER_MEDIUM = 'w342' as const
 export const TMDB_IMAGE_SIZE_POSTER_ORIGINAL = 'original' as const
 export const TMDB_IMAGE_SIZE_BACKDROP_ORIGINAL = 'original' as const
+
+export const TMDB_GENRE_MAP: Record<number, string> = {
+  28: 'Action',
+  12: 'Adventure',
+  16: 'Animation',
+  35: 'Comedy',
+  80: 'Crime',
+  99: 'Documentary',
+  18: 'Drama',
+  10751: 'Family',
+  14: 'Fantasy',
+  36: 'History',
+  27: 'Horror',
+  10402: 'Music',
+  9648: 'Mystery',
+  10749: 'Romance',
+  878: 'Science Fiction',
+  10770: 'TV Movie',
+  53: 'Thriller',
+  10752: 'War',
+  37: 'Western',
+}


### PR DESCRIPTION
Closes #5

## Summary

- Adds `/discover` page that shows one TMDB popular movie at a time for the user to rate, set a watch date on, or skip
- The discover card shows backdrop, poster, title, year, genres, runtime, overview, and TMDB vote — plus an inline rating slider and date picker
- Pre-fetches the next batch before the queue runs dry, so there's no loading spinner between cards
- Adds pluggable recommendation engine in `lib/recommender/` — the current strategy filters TMDB popular movies by user exclusions; swapping in a smarter algorithm means only changing the strategy function
- Hard exclusions (rated / watched): never resurface
- Recent skips (< 30 days): deprioritised to the back of the candidate pool, not permanently hidden — so a skipped movie can come back after the cooldown
- New `skips` table records skip interactions for future ML signals (timestamps, per-user)

## Architecture

```
lib/recommender/index.ts   ← strategy interface + popularMoviesStrategy
db/queries.ts              ← getUserExclusions (hard + recentlySkipped)
actions/index.ts           ← getDiscoverBatch, skipMovie
components/discover-queue  ← client queue manager (prefetch + advance)
components/discover-card   ← rich card with inline rate/date/skip actions
app/discover/page.tsx      ← server page, fetches initial batch
```

## Test plan

- [ ] Visit `/discover` as an authenticated user — initial batch loads without flicker
- [ ] Rate a movie — card advances to next, rated movie does not reappear
- [ ] Set watch date before rating — both are saved
- [ ] Skip a movie — card advances, skipped movie does not reappear within ~30 days
- [ ] Rate/skip until queue empties — new batch loads silently in the background before exhaustion
- [ ] Run `bun run db:migrate` to apply the `skips` table migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)